### PR TITLE
Create product detail page front

### DIFF
--- a/app/assets/javascripts/detail_pages.js
+++ b/app/assets/javascripts/detail_pages.js
@@ -1,0 +1,28 @@
+$(function(){
+  $(".header-nav").find("a").hover(
+    function(){
+      $(this).css('color', 'mediumturquoise')
+    },
+    function(){
+      $(this).css('color', '')
+    }
+  )
+
+  $(".like-btn").hover(
+    function(){
+      $(this).css('opacity', '0.5');
+    },
+    function(){
+      $(this).css('opacity', '');
+    }
+  )
+
+  $(".option-btn").hover(
+    function(){
+      $(this).css('opacity', '0.5');
+    },
+    function(){
+      $(this).css('opacity', '');
+    }
+  )
+})

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 @import "config/color";
 @import "reset";
 @import "tops.scss";
+@import "detail_pages.scss";
 @import "font-awesome-sprockets";
 @import "font-awesome";

--- a/app/assets/stylesheets/detail_pages.scss
+++ b/app/assets/stylesheets/detail_pages.scss
@@ -1,0 +1,174 @@
+.header-nav{
+  border-top: 1px solid;
+  border-color: #eee;
+  box-shadow: 0 3px 3px 0 rgb(211, 211, 211);
+  padding: 0 60px;
+  margin-top: 15px;
+  position: relative;
+  ul{
+    max-width: 1160px;
+    margin: 0 auto;
+    text-align: left;
+    padding: 16px 0;
+    display: flex;
+    li{
+      margin-right: 10px;
+      a{
+        text-decoration: none;
+        color: rgb(41, 41, 41);
+        font-size: 14px;
+      }
+      .current-list{
+        font-weight: bold;
+      }
+    }
+  }
+}
+
+.main-contents__product{
+  background-color: #f8f8f8;
+  .content-box{
+    padding: 40px;
+    margin: 0 auto;
+    .detail-content{
+      width: 700px;
+      margin: 0 auto;
+      .product-box{
+        background-color: #fff;
+        padding: 24px 40px 40px;
+        &__name{
+          font-size: 24px;
+          font-weight: bold;
+          text-align: center;
+          margin-bottom: 16px;
+        }
+        &__images{
+          ul{
+            text-align: center;
+            .main-image{
+              height: 360px;
+              width: 560px;
+              object-fit: cover;
+            }
+            ul{
+              display: flex;
+              justify-content: center;
+              margin-top: 10px;
+              li{
+                width: 25%;
+                margin-right: 10px;
+                .sub-images{
+                  object-fit: cover;
+                  height: 87px;
+                }  
+              }
+            }  
+          }
+        }
+        &__price{
+          margin: 20px 0;
+          text-align: center;
+          .product-price{
+            font-size: 46px;
+            font-weight: bold;
+          }
+        }
+        &__text{
+          font-size: 18px;
+          margin-bottom: 30px;
+        }
+        &__table{
+          table{
+            width: 100%;
+            height: 375px;
+            border: 1px solid #f8f8f8;
+            margin-bottom: 30px;
+            th{
+              width: 20%;
+              background-color: #eee;
+              text-align: center;
+              border: 1px solid #dedede;
+              padding: 8px;
+              font-size: 14px;
+            }
+            td{
+              width: 61%;
+              padding: 15px;
+              border: 1px solid #dedede;
+              font-size: 14px;
+              a{
+                color: mediumturquoise;
+                text-decoration: none;
+              }
+            }
+          }
+        }
+        &__option{
+          display: flex;
+          justify-content: space-between;
+          .like-btn{
+            color: mediumturquoise;
+            border: 1px solid orange;
+            border-radius: 40px;
+            padding: 6px 10px;
+          }
+          .option-btn{
+            margin-top: 10px;
+            a{
+              color: rgb(41, 41, 41);
+              text-decoration: none;
+              font-size: 14px;
+              border: 1px solid rgb(41, 41, 41);
+              border-radius: 4px;
+              padding: 8px 10px;  
+            }
+          }
+        }
+      }
+      .comment-box{
+        padding: 24px;
+        margin: 10px 0;
+        background-color: #fff;
+        text-align: center;
+        #comment-area{
+          width: calc(100% - 20px);
+          min-height: 86px;
+          padding: 10px;
+        }
+        .comment-note{
+          background-color: #f8f8f8;
+          font-size: 14px;
+          padding: 8px;
+          margin: 10px 0;
+          text-align: left;
+        }
+        .comment-btn{
+          width: 60%;
+          height: 54px;
+          color: #fff;
+          font-size: 18px;
+          border-radius: 100px;
+          background-color: mediumturquoise;
+          margin-top: 20px;
+        }
+      }
+    }
+    .around-link{
+      display: flex;
+      justify-content: space-between;
+      a{
+        text-decoration: none;
+        color: mediumturquoise;
+      }
+    }
+    .root-category{
+      margin-top: 20px;
+      a{
+        font-size: 22px;
+        font-weight: bold;
+        text-decoration: none;
+        color: mediumturquoise;  
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/tops.scss
+++ b/app/assets/stylesheets/tops.scss
@@ -56,6 +56,8 @@
             padding-top: 16px;
             background-color: $white;
             display: none;
+            position: relative;
+            z-index: 2;
             .category-type__item{
               border-bottom: solid;
               border-bottom-width: 1px;

--- a/app/controllers/detail_pages_controller.rb
+++ b/app/controllers/detail_pages_controller.rb
@@ -1,0 +1,5 @@
+class DetailPagesController < ApplicationController
+  def index
+    
+  end
+end

--- a/app/helpers/detail_pages_helper.rb
+++ b/app/helpers/detail_pages_helper.rb
@@ -1,0 +1,2 @@
+module DetailPagesHelper
+end

--- a/app/views/detail_pages/_main-contents-detail.html.haml
+++ b/app/views/detail_pages/_main-contents-detail.html.haml
@@ -1,0 +1,116 @@
+.header-nav
+  %ul
+    %li
+      =link_to "#" do
+        FURIMA
+    %li
+      =icon('fa', 'angle-right')
+    %li
+      =link_to "#" do
+        メンズ
+    %li
+      =icon('fa', 'angle-right')
+    %li
+      =link_to "#" do
+        ジャケット/アウター
+    %li
+      =icon('fa', 'angle-right')
+    %li
+      =link_to "#" do
+        ノーカラージャケット
+    %li
+      =icon('fa', 'angle-right')
+    %li.current-list
+      product2
+
+.main-contents__product
+  .content-box
+    .detail-content
+      .product-box
+        %h2.product-box__name
+          product2
+        .product-box__images
+          %ul
+            %li
+              =image_tag src="/assets/a004.png", class: "main-image"
+            %ul
+              %li
+                =image_tag src="/assets/a004.png", class: "sub-images", size: "140"
+              %li
+                =image_tag src="/assets/a001.png", class: "sub-images", size: "140"
+              %li
+                =image_tag src="/assets/a007.png", class: "sub-images", size: "140"
+        .product-box__price
+          .product-price
+            ¥20000
+          .postage
+            （税込）送料込み
+        .product-box__text
+          親譲りの無鉄砲で小供の時から損ばかりしている。小学校に居る時分学校の二階から飛び降りて一週間ほど腰を抜かした事がある。なぜそんな無闇をしたと聞く人があるかも知れぬ。別段深い理由でもない。新築の二階から首を出していたら、同級生の一人が冗談に、いくら威張っても、そこから飛び降りる事は出来まい。弱虫やーい。と囃したからである。小使に負ぶさって帰って来た時、おやじが大きな眼をして二階ぐらいから飛び降りて腰
+        .product-box__table
+          %table
+            %tbody
+              %tr
+                %th 出品者
+                %td hoge
+              %tr
+                %th カテゴリー
+                %td
+                  =link_to "#" do
+                    メンズ
+                  %br/
+                  =link_to "#" do
+                    ジャケット/アウター
+                  %br/
+                  =link_to "#" do
+                    ノーカラージャケット
+              %tr
+                %th ブランド
+                %td
+              %tr
+                %th 商品のサイズ
+                %td
+              %tr
+                %th 商品の状態
+                %td 新品/未使用
+              %tr
+                %th 配送料の負担
+                %td 着払い（購入者負担）
+              %tr
+                %th 発送元の地域
+                %td
+                  =link_to "#" do
+                    青森
+              %tr
+                %th 発送日の目安
+                %td 1-2日で発送
+        .product-box__option
+          .like-btn
+            =icon('fa', 'star', class: "star-icon")
+            お気に入り 0
+          .option-btn
+            =link_to "#" do
+              =icon('fa', 'flag', class: "flag-icon")
+              不適切な商品の通報
+      .comment-box
+        %form{:action => "#", :method => "post", :class => "comment-form"}
+          %textarea{:required => "required", :name => "inputArea", :id => "comment-area"}
+          %p.comment-note
+            相手のことを考え丁寧なコメントを心がけましょう。
+            %br/
+            不快な言葉遣いなどは利用制限や退会処分となることがあります。
+          %button{:type => "submit", :name => "button", :class => "comment-btn"}
+            =icon('fa', 'comment', class: "comment-icon")
+            コメントする
+      %ul.around-link
+        %li
+          =link_to "#" do
+            =icon('fa', 'angle-left')
+            前の商品
+        %li
+          =link_to "#" do
+            後の商品
+            =icon('fa', 'angle-right')
+      .root-category
+        =link_to "#" do
+          メンズをもっと見る

--- a/app/views/detail_pages/index.html.haml
+++ b/app/views/detail_pages/index.html.haml
@@ -1,0 +1,5 @@
+= render 'shared/header'
+= render 'main-contents-detail'
+= render 'shared/banner-contents'
+= render 'shared/footer'
+= render 'shared/exhibitionBtn'

--- a/app/views/tops/_main-contents-top.html.haml
+++ b/app/views/tops/_main-contents-top.html.haml
@@ -88,7 +88,7 @@
         %h3.pickup-head
           新規投稿商品
       .pickup-lists
-        =link_to "#", class: "product-list" do
+        =link_to detail_pages_path, class: "product-list" do
           .product-list__image
             =image_tag src="a004.png", class: "product-images"
           .product-list__body
@@ -103,7 +103,7 @@
                   0
               %p
                 (税込)
-        =link_to "#", class: "product-list" do
+        =link_to detail_pages_path, class: "product-list" do
           .product-list__image
             =image_tag src="a007.png", class: "product-images"
           .product-list__body
@@ -118,7 +118,7 @@
                   0
               %p
                 (税込)
-        =link_to "#", class: "product-list" do
+        =link_to detail_pages_path, class: "product-list" do
           .product-list__image
             =image_tag src="a001.png", class: "product-images"
           .product-list__body
@@ -141,7 +141,7 @@
         %h3.pickup-head
           アーカイバ
       .pickup-lists
-        =link_to "#", class: "product-list" do
+        =link_to detail_pages_path, class: "product-list" do
           .product-list__image
             =image_tag src="a004.png", class: "product-images"
           .product-list__body
@@ -156,7 +156,7 @@
                   0
               %p
                 (税込)
-        =link_to "#", class: "product-list" do
+        =link_to detail_pages_path, class: "product-list" do
           .product-list__image
             =image_tag src="a007.png", class: "product-images"
           .product-list__body
@@ -171,7 +171,7 @@
                   0
               %p
                 (税込)
-        =link_to "#", class: "product-list" do
+        =link_to detail_pages_path, class: "product-list" do
           .product-list__image
             =image_tag src="a001.png", class: "product-images"
           .product-list__body

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
   root "tops#index"
+
+  resources :detail_pages, only: [:index]
 end

--- a/spec/helpers/detail_pages_helper_spec.rb
+++ b/spec/helpers/detail_pages_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the DetailPagesHelper. For example:
+#
+# describe DetailPagesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe DetailPagesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/detail_pages_request_spec.rb
+++ b/spec/requests/detail_pages_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "DetailPages", type: :request do
+
+end


### PR DESCRIPTION
## What
- 商品詳細ページようにコントローラー、ルーティングを作成。
- detail_pages_controllerのindexページを作成。
```
header、banner、footer部分はrenderで使用。メインコンテンツ部分を作成。
```

## Why
- 各商品の詳細を見るためのフロントページ作成のため。